### PR TITLE
Simple mongodump/mongorestore alternative that does not require users to install those tools

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /package-lock.json
+/test/test.snapshot

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright (c) 2025 Apostrophe Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Because the format of mongodb archive files is a bit more complicated and appare
 
 ## Installation
 ```bash
-npm install @apostrophecms/db-snapshot
+npm install @apostrophecms/mongodb-snapshot
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ npm install @apostrophecms/db-snapshot
 // writing
 
 const { MongoClient } = require('mongodb');
-const { write } = require('@apostrophecms/db-snapshot');
+const { write } = require('@apostrophecms/mongodb-snapshot');
 
 async function saveASnapshot() {
   const client = new MongoClient(yourMongodbUriGoesHere, { useUnifiedTopology: true });
@@ -30,7 +30,7 @@ async function saveASnapshot() {
 
 ```javascript
 const { MongoClient } = require('mongodb');
-const { erase, read } = require('@apostrophecms/db-snapshot');
+const { erase, read } = require('@apostrophecms/mongodb-snapshot');
 
 async function saveASnapshot() {
   const client = new MongoClient(yourMongodbUriGoesHere, { useUnifiedTopology: true });

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# @apostrophecms/mongodb-snapshot
+
+A simple nodejs utility library to create and restore snapshots of mongodb databases without the need for `mongodump` and `mongorestore` to be installed. This reduces unnecessary dependencies, especially when relying on MongoDB Atlas for MongoDB hosting.
+
+Because the format of mongodb archive files is a bit more complicated and apparently undocumented, and the BSON format has no readily available streaming support in JavaScript, this module **does not** read and write mongodump files. Instead it reads and writes a simple format based on EJSON (Extended JSON).
+
+## Installation
+```bash
+npm install @apostrophecms/db-snapshot
+```
+
+## Usage
+
+```javascript
+// Note: ESM import syntax also works.
+
+// writing
+
+const { MongoClient } = require('mongodb');
+const { write } = require('@apostrophecms/db-snapshot');
+
+async function saveASnapshot() {
+  const client = new MongoClient(yourMongodbUriGoesHere, { useUnifiedTopology: true });
+  await client.connect();
+  const db = await client.db();
+  // Writes the contents of db to myfilename.snapshot, including indexes
+  await write(db, 'myfilename.snapshot');
+}
+```
+
+```javascript
+const { MongoClient } = require('mongodb');
+const { erase, read } = require('@apostrophecms/db-snapshot');
+
+async function saveASnapshot() {
+  const client = new MongoClient(yourMongodbUriGoesHere, { useUnifiedTopology: true });
+  await client.connect();
+  const db = await client.db();
+  // If you want to replace the current contents and avoid unique key errors and/or duplicate
+  // documents, call erase first
+  await erase(db);
+  await read(db, 'myfilename.snapshot');
+```
+
+## Limitations
+
+Correctness comes before performance, for now. Sensible amounts of parallelism would help.
+
+## Credits
+
+This module was [originally created for use with ApostropheCMS](https://apostrophecms.com), an open-source Node.js CMS with robust support for in-context, on-page editing, multitenant, multisite projects and lots of other great features worth checking out.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,99 @@
+"use strict";
+
+const readline = require('readline');
+const { EJSON } = require('bson');
+
+const { createReadStream, createWriteStream } = require('fs');
+const assert = require('assert');
+
+module.exports = {
+  async read(db, filename) {
+    const input = createReadStream(filename);
+    const rl = readline.createInterface({
+      input,
+      crlfDelay: Infinity
+    });
+
+    let collectionName;
+    let collection;
+    let version;
+
+    for await (const line of rl) {
+      const data = EJSON.parse(line);
+      if (data.metaType === 'version') {
+        assert.strictEqual(data.value, 1);
+        version = data.value;
+      } else if (data.metaType === 'collection') {
+        assert(version);
+        collectionName = data.value;
+        collection = db.collection(collectionName);
+      } else if (data.metaType === 'index') {
+        assert(collection);
+        const {
+          key,
+          v,
+          ...rest
+        } = data.value;
+        await collection.createIndex(key, rest);
+      } else if (data.metaType === 'doc') {
+        assert(collection);
+        await collection.insertOne(data.value);
+      }
+    }
+  },
+  async write(db, filename) {
+    const output = createWriteStream(filename);
+    const collectionsInfo = await db.listCollections().toArray();
+    const collectionNames = collectionsInfo.map(({ name }) => name);
+    write('version', 1);
+    for (const name of collectionNames) {
+      const collection = db.collection(name);
+      await write('collection', name);
+      const indexes = await collection.listIndexes().toArray();
+      for (const index of indexes) {
+        write('index', index);
+      }
+      // Get all the _id properties in one go. In theory, we could run out of RAM
+      // here, but that is very unlikely at a database size that would be encountered
+      // in Apostrophe.
+      const idsInfo = await collection.find({}, { _id: 1 }).toArray();
+      const _ids = idsInfo.map(({ _id }) => _id);
+      // TODO: moderate parallelism would greatly improve performance. We can't assume
+      // that fetching hundreds of documents is RAM-safe, but we could be doing
+      // perhaps 5 in parallel. The end result still has to be written in order though
+      for (const _id of _ids) {
+        const doc = await collection.findOne({ _id });
+        if (doc) {
+          write('doc', doc);
+        } else {
+          // This is not an error, documents do go away between operations sometimes
+        }
+      }
+    }
+    async function write(metaType, value) {
+      const ready = output.write(EJSON.stringify({
+        metaType,
+        value
+      }) + '\n');
+      // Handle backpressure so we don't buffer the entire database into RAM
+      if (!ready) {
+        await new Promise(resolve => {
+          output.once('drain', () => resolve());
+        });
+      }
+    }
+    output.end();
+    await new Promise((resolve, reject) => {
+      output.on('finish', () => resolve());
+      output.on('error', e => reject(e));
+    });
+  },
+  async erase(db) {
+    const collectionsInfo = await db.listCollections().toArray();
+    const collectionNames = collectionsInfo.map(({ name }) => name);
+    for (const name of collectionNames) {
+      const collection = db.collection(name);
+      await collection.drop();
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/apostrophecms/db-snapshot.git"
+    "url": "git+https://github.com/apostrophecms/mongodb-snapshot.git"
   },
   "author": "Apostrophe Technologies",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/apostrophecms/db-snapshot/issues"
+    "url": "https://github.com/apostrophecms/mongodb-snapshot/issues"
   },
-  "homepage": "https://github.com/apostrophecms/db-snapshot#readme",
+  "homepage": "https://github.com/apostrophecms/mongodb-snapshot#readme",
   "dependencies": {
     "bson": "^6.10.1",
     "mongodb": "^6.12.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@apostrophecms/mongodb-snapshot",
+  "version": "1.0.0",
+  "description": "Save and restore mongodb snapshots without mongodump and mongorestore",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apostrophecms/db-snapshot.git"
+  },
+  "author": "Apostrophe Technologies",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/apostrophecms/db-snapshot/issues"
+  },
+  "homepage": "https://github.com/apostrophecms/db-snapshot#readme",
+  "dependencies": {
+    "bson": "^6.10.1",
+    "mongodb": "^6.12.0"
+  },
+  "devDependencies": {
+    "mocha": "^11.0.1"
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const uri = 'mongodb://localhost:27017/db-snapshot-test-only';
+
+const { MongoClient } = require('mongodb');
+
+const assert = require('assert');
+
+const { read, write, erase } = require('../index.js');
+
+
+let client, db;
+
+describe('test db-snapshot', function() {
+  before(async function() {
+    await connect();
+    await erase(db);
+  });
+  after(async function() {
+    await close();
+  });
+  it('can write a snapshot', async function() {
+    const docs = db.collection('docs');
+    await docs.insertOne({
+      tull: '35 cents please'
+    });
+    await docs.insertOne({
+      tull: 'jethro'
+    });
+    // Test whether indexes are included in shapshots
+    await docs.createIndex({
+      tull: 1
+    }, {
+      unique: true
+    });
+    await write(db, `${__dirname}/test.snapshot`);
+  });
+  it('can read a snapshot', async function() {
+    const docs = db.collection('docs');
+    await docs.deleteMany({});
+    await docs.dropIndexes();
+    await read(db, `${__dirname}/test.snapshot`);
+    const result = await docs.find({}).sort({ tull: 1 }).toArray();
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].tull, '35 cents please');
+    assert.strictEqual(result[1].tull, 'jethro');
+    assert.rejects(async function() {
+      // Should be blocked by the index if it was restored properly
+      return docs.insertOne({
+        tull: 'jethro'
+      });
+    });
+  });
+});
+
+async function connect() {
+  client = new MongoClient(uri, { useUnifiedTopology: true });
+  await client.connect();
+  db = await client.db();
+  return db;
+}
+
+async function close() {
+  await client.close();
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const uri = 'mongodb://localhost:27017/db-snapshot-test-only';
+const uri = 'mongodb://localhost:27017/mongodb-snapshot-test-only';
 
 const { MongoClient } = require('mongodb');
 
@@ -11,7 +11,7 @@ const { read, write, erase } = require('../index.js');
 
 let client, db;
 
-describe('test db-snapshot', function() {
+describe('test mongodb-snapshot', function() {
   before(async function() {
     await connect();
     await erase(db);


### PR DESCRIPTION
This is a simple alternative that we can use to create simple tasks for saving and restoring entire databases, such as for fixture purposes, without adding yet more install steps for newcomers.

As of now it focuses on correctness (note the tests), not speed. It will never be as fast as mongodump/mongorestore.

The name deliberately does NOT evoke "dump" and "restore" because the storage format is different, it is one that can be implemented quickly and safely and portably.