### PR TITLE
Command line utilities & additional debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,29 @@
 # @apostrophecms/mongodb-snapshot
 
-A simple nodejs utility library to create and restore snapshots of mongodb databases without the need for `mongodump` and `mongorestore` to be installed. This reduces unnecessary dependencies, especially when relying on MongoDB Atlas for MongoDB hosting.
+A simple nodejs utility library to create and restore snapshots of mongodb databases without the need for `mongodump` and `mongorestore` to be installed. This reduces unnecessary dependencies on packages users may not be eager to install, especially developers relying solely on MongoDB Atlas for MongoDB hosting.
 
 Because the format of mongodb archive files is a bit more complicated and apparently undocumented, and the BSON format has no readily available streaming support in JavaScript, this module **does not** read and write mongodump files. Instead it reads and writes a simple format based on EJSON (Extended JSON).
 
+As a bonus, command line `mongodb-snapshot-write` and `mongodb-snapshot-read` utilities are provided. Of course these do not perform as quickly as `mongodump` and `mongorestore`.
+
 ## Installation
 ```bash
+# If you want to use the utilities
+npm install -g @apostrophecms/mongodb-snapshot
+
+# If you want to use the library in your nodejs code
 npm install @apostrophecms/mongodb-snapshot
 ```
 
-## Usage
+## Command line usage
+
+```bash
+mongodb-snapshot-write --from=mongodb://localhost:27017/mydbname --to=myfile.snapshot
+# add --erase ONLY if you want the previous contents removed first!
+mongodb-snapshot-read --from=myfile.snapshot --to=mongodb://localhost:27017/mydbname --erase
+```
+
+## Node.js API usage
 
 ```javascript
 // Note: ESM import syntax also works.
@@ -20,7 +34,7 @@ const { MongoClient } = require('mongodb');
 const { write } = require('@apostrophecms/mongodb-snapshot');
 
 async function saveASnapshot() {
-  const client = new MongoClient(yourMongodbUriGoesHere, { useUnifiedTopology: true });
+  const client = new MongoClient(yourMongodbUriGoesHere);
   await client.connect();
   const db = await client.db();
   // Writes the contents of db to myfilename.snapshot, including indexes
@@ -33,13 +47,14 @@ const { MongoClient } = require('mongodb');
 const { erase, read } = require('@apostrophecms/mongodb-snapshot');
 
 async function saveASnapshot() {
-  const client = new MongoClient(yourMongodbUriGoesHere, { useUnifiedTopology: true });
+  const client = new MongoClient(yourMongodbUriGoesHere);
   await client.connect();
   const db = await client.db();
   // If you want to replace the current contents and avoid unique key errors and/or duplicate
   // documents, call erase first
   await erase(db);
   await read(db, 'myfilename.snapshot');
+}
 ```
 
 ## Limitations

--- a/bin/mongodb-snapshot-read
+++ b/bin/mongodb-snapshot-read
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+const { MongoClient } = require('mongodb');
+const { erase, read } = require('../index.js');
+const argv = require('boring')();
+
+(async () => {
+  if (!(argv.from && argv.to)) {
+    fail(
+      'Usage: mongodb-snapshot-read --from=filename.snapshot --to=mongodb://localhost:27017/dbname [--erase]\n\n' +
+      'This command will read the snapshot into the database. If --erase is given,\n' +
+      'ALL previous contents of the database are removed first.'
+    );
+  }
+  try {
+    const client = new MongoClient(argv.to);
+    await client.connect();
+    const db = await client.db();
+    if (!fs.existsSync(argv.from)) {
+      fail(`${from} does not exist`);
+    }
+    // If you want to replace the current contents and avoid unique key errors and/or duplicate
+    // documents, call erase first
+    if (argv.erase) {
+      await erase(db);
+    }
+    await read(db, argv.from);
+  } catch (e) {
+    fail(e);
+  }
+})();
+
+function fail(e) {
+  console.error(e);
+  process.exit(1);
+}

--- a/bin/mongodb-snapshot-read
+++ b/bin/mongodb-snapshot-read
@@ -3,6 +3,7 @@
 const { MongoClient } = require('mongodb');
 const { erase, read } = require('../index.js');
 const argv = require('boring')();
+const { existsSync } = require('fs');
 
 (async () => {
   if (!(argv.from && argv.to)) {
@@ -16,7 +17,7 @@ const argv = require('boring')();
     const client = new MongoClient(argv.to);
     await client.connect();
     const db = await client.db();
-    if (!fs.existsSync(argv.from)) {
+    if (!existsSync(argv.from)) {
       fail(`${from} does not exist`);
     }
     // If you want to replace the current contents and avoid unique key errors and/or duplicate
@@ -25,6 +26,7 @@ const argv = require('boring')();
       await erase(db);
     }
     await read(db, argv.from);
+    await client.close();
   } catch (e) {
     fail(e);
   }

--- a/bin/mongodb-snapshot-write
+++ b/bin/mongodb-snapshot-write
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const { MongoClient } = require('mongodb');
+const { write } = require('../index.js');
+const argv = require('boring')();
+
+(async () => {
+  if (!(argv.from && argv.to)) {
+    fail(
+      'Usage: mongodb-snapshot-write --from=mongodb://localhost:27017/dbname --to=some-filename.snapshot\n\n' +
+      'This command will write a database snapshot to a file.'
+    );
+  }
+  try {
+    const client = new MongoClient(argv.from);
+    await client.connect();
+    const db = await client.db();
+    // If you want to replace the current contents and avoid unique key errors and/or duplicate
+    // documents, call erase first
+    await write(db, argv.to);
+  } catch (e) {
+    fail(e);
+  }
+})();
+
+function fail(e) {
+  console.error(e);
+  process.exit(1);
+}

--- a/bin/mongodb-snapshot-write
+++ b/bin/mongodb-snapshot-write
@@ -18,6 +18,7 @@ const argv = require('boring')();
     // If you want to replace the current contents and avoid unique key errors and/or duplicate
     // documents, call erase first
     await write(db, argv.to);
+    await client.close();
   } catch (e) {
     fail(e);
   }

--- a/index.js
+++ b/index.js
@@ -45,13 +45,13 @@ module.exports = {
     const output = createWriteStream(filename);
     const collectionsInfo = await db.listCollections().toArray();
     const collectionNames = collectionsInfo.map(({ name }) => name);
-    write('version', 1);
+    await write('version', 1);
     for (const name of collectionNames) {
       const collection = db.collection(name);
       await write('collection', name);
       const indexes = await collection.listIndexes().toArray();
       for (const index of indexes) {
-        write('index', index);
+        await write('index', index);
       }
       // Get all the _id properties in one go. In theory, we could run out of RAM
       // here, but that is very unlikely at a database size that would be encountered
@@ -64,7 +64,7 @@ module.exports = {
       for (const _id of _ids) {
         const doc = await collection.findOne({ _id });
         if (doc) {
-          write('doc', doc);
+          await write('doc', doc);
         } else {
           // This is not an error, documents do go away between operations sometimes
         }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,15 @@
   },
   "homepage": "https://github.com/apostrophecms/mongodb-snapshot#readme",
   "dependencies": {
+    "boring": "^1.1.1",
     "bson": "^6.10.1",
     "mongodb": "^6.12.0"
   },
   "devDependencies": {
     "mocha": "^11.0.1"
+  },
+  "bin": {
+    "mongodb-snapshot-write": "./bin/mongodb-snapshot-write",
+    "mongodb-snapshot-read": "./bin/mongodb-snapshot-read"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -54,7 +54,7 @@ describe('test mongodb-snapshot', function() {
 });
 
 async function connect() {
-  client = new MongoClient(uri, { useUnifiedTopology: true });
+  client = new MongoClient(uri);
   await client.connect();
   db = await client.db();
   return db;


### PR DESCRIPTION
These utilities make it easier to get the benefit of the module and allowed me to quickly debug an issue that wouldn't be spotted in a simple unit test.

The command line utility can restore a 150MB database in 26 seconds. That is much, much slower than mongodump / mongorestore but the databases we're working with for our intended application are tiny. I tried simple batching approaches but it yielded no benefit. Perhaps it can be sped up later.